### PR TITLE
update fs.rmdir -> fs.rm

### DIFF
--- a/src/utils/tmpfile.ts
+++ b/src/utils/tmpfile.ts
@@ -28,6 +28,6 @@ const withTempDir = async <T>(handler: TempDirHandler<T>) => {
   try {
     return await handler(dir);
   } finally {
-    fs.rmdir(dir, { recursive: true });
+    fs.rm(dir, { recursive: true });
   }
 };


### PR DESCRIPTION
```
(node:52482) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```