### PR TITLE
Succinct roles impl and test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1374,9 +1374,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.12.tgz",
-      "integrity": "sha512-FgD3NtTAKvyMmD44T07zz2fEf+OKwutgBCEVM8GcvMGVGaDktiLNTDvPwC/LUe3PinMW+X6CuLOF2Ui1mAlSXg==",
+      "version": "18.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
+      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -6940,9 +6940,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.12.tgz",
-      "integrity": "sha512-FgD3NtTAKvyMmD44T07zz2fEf+OKwutgBCEVM8GcvMGVGaDktiLNTDvPwC/LUe3PinMW+X6CuLOF2Ui1mAlSXg==",
+      "version": "18.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
+      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/src/__tests__/models/SuccinctRoles.test.ts
+++ b/src/__tests__/models/SuccinctRoles.test.ts
@@ -235,25 +235,8 @@ describe('SuccinctRoles', () => {
 
       it('returns the expected JSON', () => {
         expect(succinctRoles.toJSON()).toEqual({
-          bitLength: opts.bitLength,
-          namePrefix: opts.namePrefix,
-          numberOfBins: 2,
-          suffixLen: 1,
-          keyids: opts.keyIDs,
-          threshold: opts.threshold,
-          ...opts.unrecognizedFields,
-        });
-      });
-    });
-    describe('when bit length is 32', () => {
-      const succinctRoles = new SuccinctRoles({ ...opts, bitLength: 32 });
-
-      it('returns the expected JSON', () => {
-        expect(succinctRoles.toJSON()).toEqual({
-          bitLength: 32,
-          namePrefix: opts.namePrefix,
-          numberOfBins: 4294967296,
-          suffixLen: 8,
+          bit_length: opts.bitLength,
+          name_prefix: opts.namePrefix,
           keyids: opts.keyIDs,
           threshold: opts.threshold,
           ...opts.unrecognizedFields,

--- a/src/__tests__/models/SuccinctRoles.test.ts
+++ b/src/__tests__/models/SuccinctRoles.test.ts
@@ -40,86 +40,6 @@ describe('SuccinctRoles', () => {
     });
   });
 
-  describe('#isDelegatedRole', () => {
-    const succinctRoles = new SuccinctRoles({
-      ...opts,
-      bitLength: 5,
-    });
-
-    const falseRoleNameExamples = [
-      'foo',
-      'bin-',
-      'bin-s',
-      'bin-0t',
-      'bin-20',
-      'bin-100',
-    ];
-
-    const trueNameExamples = ['bin-00', 'bin-0f', 'bin-1f'];
-
-    describe('when called with WRONG role names', () => {
-      it('returns false', () => {
-        falseRoleNameExamples.forEach((roleName) => {
-          expect(succinctRoles.isDelegatedRole(roleName)).toBeFalsy();
-        });
-      });
-    });
-    describe('when called with CORRECT role names', () => {
-      it('returns false', () => {
-        trueNameExamples.forEach((roleName) => {
-          expect(succinctRoles.isDelegatedRole(roleName)).toBeTruthy();
-        });
-      });
-    });
-  });
-
-  describe('#getRoleForTarget', () => {
-    const succinctRoles = new SuccinctRoles({ ...opts, bitLength: 8 });
-    const targetNameExamples = [
-      'target-0',
-      'target-1',
-      'target-2',
-      'target-3',
-      'target-4',
-      'target-5',
-    ];
-    const targetBinCorrectExamples = [
-      'bin-8b',
-      'bin-75',
-      'bin-b5',
-      'bin-a3',
-      'bin-8c',
-      'bin-14',
-    ];
-    const targetBinWrongExamples = [
-      'bin-00',
-      'bin-00',
-      'bin-00',
-      'bin-00',
-      'bin-00',
-      'bin-00',
-    ];
-
-    describe('when checked with CORRECT target bin examples', () => {
-      it('returns true', () => {
-        targetNameExamples.forEach((targetName, index) => {
-          expect(succinctRoles.getRoleForTarget(targetName)).toBe(
-            targetBinCorrectExamples[index]
-          );
-        });
-      });
-    });
-    describe('when checked with WRONG target bin examples', () => {
-      it('returns false', () => {
-        targetNameExamples.forEach((targetName, index) => {
-          expect(succinctRoles.getRoleForTarget(targetName)).not.toBe(
-            targetBinWrongExamples[index]
-          );
-        });
-      });
-    });
-  });
-
   describe('#equals', () => {
     const succinctRoles = new SuccinctRoles(opts);
 
@@ -184,6 +104,53 @@ describe('SuccinctRoles', () => {
     });
   });
 
+  describe('#getRoleForTarget', () => {
+    const succinctRoles = new SuccinctRoles({ ...opts, bitLength: 8 });
+    const targetNameExamples = [
+      'target-0',
+      'target-1',
+      'target-2',
+      'target-3',
+      'target-4',
+      'target-5',
+    ];
+    const targetBinCorrectExamples = [
+      'bin-8b',
+      'bin-75',
+      'bin-b5',
+      'bin-a3',
+      'bin-8c',
+      'bin-14',
+    ];
+    const targetBinWrongExamples = [
+      'bin-00',
+      'bin-00',
+      'bin-00',
+      'bin-00',
+      'bin-00',
+      'bin-00',
+    ];
+
+    describe('when checked with CORRECT target bin examples', () => {
+      it('returns true', () => {
+        targetNameExamples.forEach((targetName, index) => {
+          expect(succinctRoles.getRoleForTarget(targetName)).toBe(
+            targetBinCorrectExamples[index]
+          );
+        });
+      });
+    });
+    describe('when checked with WRONG target bin examples', () => {
+      it('returns false', () => {
+        targetNameExamples.forEach((targetName, index) => {
+          expect(succinctRoles.getRoleForTarget(targetName)).not.toBe(
+            targetBinWrongExamples[index]
+          );
+        });
+      });
+    });
+  });
+
   describe('#getRoles', () => {
     describe('when bit length is 1', () => {
       it('returns 2 bins', () => {
@@ -225,6 +192,39 @@ describe('SuccinctRoles', () => {
 
         result = gen.next();
         expect(result.done).toEqual(true);
+      });
+    });
+  });
+
+  describe('#isDelegatedRole', () => {
+    const succinctRoles = new SuccinctRoles({
+      ...opts,
+      bitLength: 5,
+    });
+
+    const falseRoleNameExamples = [
+      'foo',
+      'bin-',
+      'bin-s',
+      'bin-0t',
+      'bin-20',
+      'bin-100',
+    ];
+
+    const trueNameExamples = ['bin-00', 'bin-0f', 'bin-1f'];
+
+    describe('when called with WRONG role names', () => {
+      it('returns false', () => {
+        falseRoleNameExamples.forEach((roleName) => {
+          expect(succinctRoles.isDelegatedRole(roleName)).toBeFalsy();
+        });
+      });
+    });
+    describe('when called with CORRECT role names', () => {
+      it('returns false', () => {
+        trueNameExamples.forEach((roleName) => {
+          expect(succinctRoles.isDelegatedRole(roleName)).toBeTruthy();
+        });
       });
     });
   });

--- a/src/__tests__/models/SuccinctRoles.test.ts
+++ b/src/__tests__/models/SuccinctRoles.test.ts
@@ -10,34 +10,32 @@ describe('SuccinctRoles', () => {
     unrecognizedFields: {},
   };
   describe('constructor', () => {
-    describe('when called with roles', () => {
-      describe('when bit length is not valid', () => {
-        it('constructs an object', () => {
-          expect(() => {
-            new SuccinctRoles({ ...opts, bitLength: -1 });
-          }).toThrow(ValueError);
-        });
-        it('constructs an object', () => {
-          expect(() => {
-            new SuccinctRoles({ ...opts, bitLength: 33 });
-          }).toThrow(ValueError);
-        });
+    describe('when bit length is not valid', () => {
+      it('constructs an object', () => {
+        expect(() => {
+          new SuccinctRoles({ ...opts, bitLength: -1 });
+        }).toThrow(ValueError);
       });
-      describe('when bit length is valid', () => {
-        it('constructs an object', () => {
-          const subject = new SuccinctRoles({ ...opts, bitLength: 1 });
-          expect(subject).toBeTruthy();
-          expect(subject.bitLength).toEqual(1);
-          expect(subject.namePrefix).toEqual(opts.namePrefix);
-          expect(subject.unrecognizedFields).toEqual(opts.unrecognizedFields);
-        });
-        it('constructs an object', () => {
-          const subject = new SuccinctRoles({ ...opts, bitLength: 32 });
-          expect(subject).toBeTruthy();
-          expect(subject.bitLength).toEqual(32);
-          expect(subject.namePrefix).toEqual(opts.namePrefix);
-          expect(subject.unrecognizedFields).toEqual(opts.unrecognizedFields);
-        });
+      it('constructs an object', () => {
+        expect(() => {
+          new SuccinctRoles({ ...opts, bitLength: 33 });
+        }).toThrow(ValueError);
+      });
+    });
+    describe('when bit length is valid', () => {
+      it('constructs an object', () => {
+        const subject = new SuccinctRoles({ ...opts, bitLength: 1 });
+        expect(subject).toBeTruthy();
+        expect(subject.bitLength).toEqual(1);
+        expect(subject.namePrefix).toEqual(opts.namePrefix);
+        expect(subject.unrecognizedFields).toEqual(opts.unrecognizedFields);
+      });
+      it('constructs an object', () => {
+        const subject = new SuccinctRoles({ ...opts, bitLength: 32 });
+        expect(subject).toBeTruthy();
+        expect(subject.bitLength).toEqual(32);
+        expect(subject.namePrefix).toEqual(opts.namePrefix);
+        expect(subject.unrecognizedFields).toEqual(opts.unrecognizedFields);
       });
     });
   });

--- a/src/__tests__/models/SuccinctRoles.test.ts
+++ b/src/__tests__/models/SuccinctRoles.test.ts
@@ -1,0 +1,338 @@
+import { ValueError } from '../../error';
+import { SuccinctRoles } from '../../models/role';
+
+describe('SuccinctRoles', () => {
+  const opts = {
+    keyIDs: [],
+    threshold: 1,
+    bitLength: 1,
+    namePrefix: 'bin',
+    unrecognizedFields: {},
+  };
+  describe('constructor', () => {
+    describe('when called with roles', () => {
+      describe('when bit length is not valid', () => {
+        it('constructs an object', () => {
+          expect(() => {
+            new SuccinctRoles({ ...opts, bitLength: -1 });
+          }).toThrow(ValueError);
+        });
+        it('constructs an object', () => {
+          expect(() => {
+            new SuccinctRoles({ ...opts, bitLength: 33 });
+          }).toThrow(ValueError);
+        });
+      });
+      describe('when bit length is valid', () => {
+        it('constructs an object', () => {
+          const subject = new SuccinctRoles({ ...opts, bitLength: 1 });
+          expect(subject).toBeTruthy();
+          expect(subject.bitLength).toEqual(1);
+          expect(subject.namePrefix).toEqual(opts.namePrefix);
+          expect(subject.unrecognizedFields).toEqual(opts.unrecognizedFields);
+        });
+        it('constructs an object', () => {
+          const subject = new SuccinctRoles({ ...opts, bitLength: 32 });
+          expect(subject).toBeTruthy();
+          expect(subject.bitLength).toEqual(32);
+          expect(subject.namePrefix).toEqual(opts.namePrefix);
+          expect(subject.unrecognizedFields).toEqual(opts.unrecognizedFields);
+        });
+      });
+    });
+  });
+
+  describe('#isDelegatedRole', () => {
+    const succinctRoles = new SuccinctRoles({
+      ...opts,
+      bitLength: 5,
+    });
+
+    const falseRoleNameExamples = [
+      'foo',
+      'bin-',
+      'bin-s',
+      'bin-0t',
+      'bin-20',
+      'bin-100',
+    ];
+
+    const trueNameExamples = ['bin-00', 'bin-0f', 'bin-1f'];
+
+    describe('when called with WRONG role names', () => {
+      it('returns false', () => {
+        falseRoleNameExamples.forEach((roleName) => {
+          expect(succinctRoles.isDelegatedRole(roleName)).toBeFalsy();
+        });
+      });
+    });
+    describe('when called with CORRECT role names', () => {
+      it('returns false', () => {
+        trueNameExamples.forEach((roleName) => {
+          expect(succinctRoles.isDelegatedRole(roleName)).toBeTruthy();
+        });
+      });
+    });
+  });
+
+  describe('#getRoleForTarget', () => {
+    const succinctRoles = new SuccinctRoles({ ...opts, bitLength: 8 });
+    const targetNameExamples = [
+      'target-0',
+      'target-1',
+      'target-2',
+      'target-3',
+      'target-4',
+      'target-5',
+    ];
+    const targetBinCorrectExamples = [
+      'bin-8b',
+      'bin-75',
+      'bin-b5',
+      'bin-a3',
+      'bin-8c',
+      'bin-14',
+    ];
+    const targetBinWrongExamples = [
+      'bin-00',
+      'bin-00',
+      'bin-00',
+      'bin-00',
+      'bin-00',
+      'bin-00',
+    ];
+
+    describe('when checked with CORRECT target bin examples', () => {
+      it('returns true', () => {
+        targetNameExamples.forEach((targetName, index) => {
+          expect(succinctRoles.getRoleForTarget(targetName)).toBe(
+            targetBinCorrectExamples[index]
+          );
+        });
+      });
+    });
+    describe('when checked with WRONG target bin examples', () => {
+      it('returns false', () => {
+        targetNameExamples.forEach((targetName, index) => {
+          expect(succinctRoles.getRoleForTarget(targetName)).not.toBe(
+            targetBinWrongExamples[index]
+          );
+        });
+      });
+    });
+  });
+
+  describe('#equals', () => {
+    const succinctRoles = new SuccinctRoles(opts);
+
+    describe('when called with a non-SuccinctRoles object', () => {
+      it('returns false', () => {
+        expect(succinctRoles.equals({} as SuccinctRoles)).toBeFalsy();
+      });
+    });
+
+    describe('when called with a SuccinctRoles object with different KeyIds', () => {
+      const other = new SuccinctRoles({
+        ...opts,
+        keyIDs: ['keyid1'],
+      });
+      it('returns false', () => {
+        expect(succinctRoles.equals(other)).toBeFalsy();
+      });
+    });
+
+    describe('when called with a SuccinctRoles object with different threshold', () => {
+      const other = new SuccinctRoles({ ...opts, threshold: 2 });
+      it('returns false', () => {
+        expect(succinctRoles.equals(other)).toBeFalsy();
+      });
+    });
+
+    describe('when called with a SuccinctRoles object with different bit length', () => {
+      const other = new SuccinctRoles({ ...opts, bitLength: 2 });
+      it('returns false', () => {
+        expect(succinctRoles.equals(other)).toBeFalsy();
+      });
+    });
+
+    describe('when called with a SuccinctRoles object with different prefix name', () => {
+      const other = new SuccinctRoles({ ...opts, namePrefix: '' });
+      it('returns false', () => {
+        expect(succinctRoles.equals(other)).toBeFalsy();
+      });
+    });
+
+    describe('when called with a SuccinctRoles object with different unrecognizedFields', () => {
+      const other = new SuccinctRoles({
+        ...opts,
+        unrecognizedFields: { others: true },
+      });
+      it('returns false', () => {
+        expect(succinctRoles.equals(other)).toBeFalsy();
+      });
+    });
+
+    describe('when called with the same SuccinctRoles object', () => {
+      it('returns true', () => {
+        expect(succinctRoles.equals(succinctRoles)).toBeTruthy();
+      });
+    });
+
+    describe('when called with the a matching succinctRoles object', () => {
+      const other = new SuccinctRoles(opts);
+      it('returns true', () => {
+        expect(succinctRoles.equals(other)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('#getRoles', () => {
+    describe('when bit length is 1', () => {
+      it('returns 2 bins', () => {
+        const succinctRoles = new SuccinctRoles(opts);
+
+        const gen = succinctRoles.getRoles();
+
+        let result = gen.next();
+        expect(result.done).toEqual(false);
+        expect(result.value).toEqual('bin-0');
+
+        result = gen.next();
+        expect(result.done).toEqual(false);
+        expect(result.value).toEqual('bin-1');
+
+        result = gen.next();
+        expect(result.done).toEqual(true);
+      });
+    });
+
+    describe('when bit length is 4', () => {
+      it('returns 16 bins', () => {
+        const succinctRoles = new SuccinctRoles({ ...opts, bitLength: 4 });
+
+        const gen = succinctRoles.getRoles();
+
+        let result = gen.next();
+        expect(result.done).toEqual(false);
+        expect(result.value).toEqual('bin-0');
+
+        for (let i = 0; i < 14; i++) {
+          result = gen.next();
+          expect(result.done).toEqual(false);
+        }
+
+        result = gen.next();
+        expect(result.done).toEqual(false);
+        expect(result.value).toEqual('bin-f');
+
+        result = gen.next();
+        expect(result.done).toEqual(true);
+      });
+    });
+  });
+
+  describe('#toJSON', () => {
+    describe('when bit length is 1', () => {
+      const succinctRoles = new SuccinctRoles(opts);
+
+      it('returns the expected JSON', () => {
+        expect(succinctRoles.toJSON()).toEqual({
+          bitLength: opts.bitLength,
+          namePrefix: opts.namePrefix,
+          numberOfBins: 2,
+          suffixLen: 1,
+          keyids: opts.keyIDs,
+          threshold: opts.threshold,
+          ...opts.unrecognizedFields,
+        });
+      });
+    });
+    describe('when bit length is 32', () => {
+      const succinctRoles = new SuccinctRoles({ ...opts, bitLength: 32 });
+
+      it('returns the expected JSON', () => {
+        expect(succinctRoles.toJSON()).toEqual({
+          bitLength: 32,
+          namePrefix: opts.namePrefix,
+          numberOfBins: 4294967296,
+          suffixLen: 8,
+          keyids: opts.keyIDs,
+          threshold: opts.threshold,
+          ...opts.unrecognizedFields,
+        });
+      });
+    });
+  });
+
+  describe('.fromJSON', () => {
+    const json = {
+      keyids: [
+        'ddfd898acbb813a32d90cdba91c992c027ad83464162856b8e7b1d98b801a294',
+      ],
+      bit_length: 1,
+      name_prefix: 'bin',
+      threshold: 1,
+      foo: 'bar',
+    };
+
+    describe('when there is a type error with keyids', () => {
+      it('throws a TypeError', () => {
+        expect(() =>
+          SuccinctRoles.fromJSON({ ...json, keyids: { abc: 2 } })
+        ).toThrowError(TypeError);
+      });
+    });
+
+    describe('when there is a type error with bit length', () => {
+      it('throws a TypeError', () => {
+        expect(() =>
+          SuccinctRoles.fromJSON({ ...json, bit_length: '1' })
+        ).toThrowError(TypeError);
+      });
+    });
+
+    describe('when there is a type error with name prefix', () => {
+      it('throws a TypeError', () => {
+        expect(() =>
+          SuccinctRoles.fromJSON({ ...json, name_prefix: 1 })
+        ).toThrowError(TypeError);
+      });
+    });
+
+    describe('when there is a type error with name threshold', () => {
+      it('throws a TypeError', () => {
+        expect(() =>
+          SuccinctRoles.fromJSON({ ...json, threshold: '1' })
+        ).toThrowError(TypeError);
+      });
+    });
+
+    describe('when the JSON is valid', () => {
+      it('returns the expected SuccinctRoles object', () => {
+        const succinctRoles = SuccinctRoles.fromJSON(json);
+
+        expect(succinctRoles.keyIDs).toBeTruthy();
+        expect(succinctRoles.keyIDs).toStrictEqual([
+          'ddfd898acbb813a32d90cdba91c992c027ad83464162856b8e7b1d98b801a294',
+        ]);
+
+        expect(succinctRoles.threshold).toBeTruthy();
+        expect(succinctRoles.threshold).toEqual(1);
+
+        expect(succinctRoles.bitLength).toBeTruthy();
+        expect(succinctRoles.bitLength).toBe(1);
+
+        expect(succinctRoles.namePrefix).toBeTruthy();
+        expect(succinctRoles.namePrefix).toBe('bin');
+
+        expect(succinctRoles.numberOfBins).toBeTruthy();
+        expect(succinctRoles.numberOfBins).toBe(2);
+
+        expect(succinctRoles.suffixLen).toBeTruthy();
+        expect(succinctRoles.suffixLen).toBe(1);
+
+        expect(succinctRoles.unrecognizedFields).toEqual({ foo: 'bar' });
+      });
+    });
+  });
+});

--- a/src/models/delegations.ts
+++ b/src/models/delegations.ts
@@ -98,19 +98,16 @@ export class Delegations {
   public static fromJSON(data: JSONObject): Delegations {
     const { keys, roles, succinct_roles, ...unrecognizedFields } = data;
 
+    let succinctRoles;
     if (isObject(succinct_roles)) {
-      return new Delegations({
-        keys: keysFromJSON(keys),
-        roles: rolesFromJSON(roles),
-        succinctRoles: SuccinctRoles.fromJSON(succinct_roles),
-        unrecognizedFields,
-      });
+      succinctRoles = SuccinctRoles.fromJSON(succinct_roles);
     }
 
     return new Delegations({
       keys: keysFromJSON(keys),
       roles: rolesFromJSON(roles),
       unrecognizedFields,
+      succinctRoles,
     });
   }
 }

--- a/src/models/delegations.ts
+++ b/src/models/delegations.ts
@@ -16,7 +16,7 @@ type KeyMap = Record<string, Key>;
 interface DelegationsOptions {
   keys: KeyMap;
   roles?: DelegatedRoleMap;
-  succinct_roles?: SuccinctRoles;
+  succinctRoles?: SuccinctRoles;
   unrecognizedFields?: Record<string, JSONValue>;
 }
 
@@ -24,7 +24,7 @@ export class Delegations {
   readonly keys: KeyMap;
   readonly roles?: DelegatedRoleMap;
   readonly unrecognizedFields?: Record<string, JSONValue>;
-  readonly succinct_roles?: SuccinctRoles;
+  readonly succinctRoles?: SuccinctRoles;
 
   constructor(options: DelegationsOptions) {
     this.keys = options.keys;
@@ -42,7 +42,7 @@ export class Delegations {
       }
     }
 
-    this.succinct_roles = options.succinct_roles;
+    this.succinctRoles = options.succinctRoles;
 
     this.roles = options.roles;
   }
@@ -59,7 +59,7 @@ export class Delegations {
         this.unrecognizedFields,
         other.unrecognizedFields
       ) &&
-      util.isDeepStrictEqual(this.succinct_roles, other.succinct_roles)
+      util.isDeepStrictEqual(this.succinctRoles, other.succinctRoles)
     );
   }
 
@@ -72,9 +72,9 @@ export class Delegations {
           yield { role: role.name, terminating: role.terminating };
         }
       }
-    } else if (this.succinct_roles) {
+    } else if (this.succinctRoles) {
       yield {
-        role: this.succinct_roles.getRoleForTarget(targetPath),
+        role: this.succinctRoles.getRoleForTarget(targetPath),
         terminating: true,
       };
     }
@@ -88,8 +88,8 @@ export class Delegations {
 
     if (this.roles) {
       json.roles = rolesToJSON(this.roles);
-    } else if (this.succinct_roles) {
-      json.succinct_roles = this.succinct_roles.toJSON();
+    } else if (this.succinctRoles) {
+      json.succinct_roles = this.succinctRoles.toJSON();
     }
 
     return json;
@@ -102,7 +102,7 @@ export class Delegations {
       return new Delegations({
         keys: keysFromJSON(keys),
         roles: rolesFromJSON(roles),
-        succinct_roles: SuccinctRoles.fromJSON(succinct_roles),
+        succinctRoles: SuccinctRoles.fromJSON(succinct_roles),
         unrecognizedFields,
       });
     }

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -47,13 +47,11 @@ export class Metadata<T extends MetadataType> implements Signable {
         keys = this.signed.delegations.keys;
         if (this.signed.delegations.roles) {
           role = this.signed.delegations.roles[delegatedRole];
-        } else if (this.signed.delegations.succinct_roles) {
+        } else if (this.signed.delegations.succinctRoles) {
           if (
-            this.signed.delegations.succinct_roles.isDelegatedRole(
-              delegatedRole
-            )
+            this.signed.delegations.succinctRoles.isDelegatedRole(delegatedRole)
           ) {
-            role = this.signed.delegations.succinct_roles;
+            role = this.signed.delegations.succinctRoles;
           }
         }
         break;

--- a/src/models/role.ts
+++ b/src/models/role.ts
@@ -236,8 +236,7 @@ export class SuccinctRoles extends Role {
 
   constructor(opts: SuccinctRolesOption) {
     super(opts);
-    const { keyIDs, threshold, bitLength, namePrefix, unrecognizedFields } =
-      opts;
+    const { bitLength, namePrefix } = opts;
 
     if (bitLength <= 0 || bitLength > 32) {
       throw new ValueError('bitLength must be between 1 and 32');
@@ -246,7 +245,7 @@ export class SuccinctRoles extends Role {
     this.bitLength = bitLength;
     this.namePrefix = namePrefix;
     this.numberOfBins = Math.pow(2, bitLength);
-    this.suffixLen = this.numberOfBins.toString(16).length;
+    this.suffixLen = (this.numberOfBins - 1).toString(16).length;
   }
 
   public equals(other: SuccinctRoles): boolean {
@@ -269,7 +268,7 @@ export class SuccinctRoles extends Role {
 
     const shiftValue = 32 - this.bitLength;
 
-    const binNumber = parseInt(hashBytes.toString('hex'), 16) >> shiftValue;
+    const binNumber = parseInt(hashBytes.toString('hex'), 16) >>> shiftValue;
 
     const suffix = binNumber.toString(16).padStart(this.suffixLen, '0');
 
@@ -294,12 +293,16 @@ export class SuccinctRoles extends Role {
       return false;
     }
 
+    // make sure the suffix is a hex string
+    if (!suffix.match(/^[0-9a-fA-F]+$/)) {
+      return false;
+    }
+
     try {
       var num = parseInt(suffix, 16);
     } catch (e) {
       return false;
     }
-
     return 0 <= num && num < this.numberOfBins;
   }
 

--- a/src/models/role.ts
+++ b/src/models/role.ts
@@ -354,10 +354,8 @@ export class SuccinctRoles extends Role {
   public toJSON(): JSONObject {
     const json: JSONObject = {
       ...super.toJSON(),
-      bitLength: this.bitLength,
-      namePrefix: this.namePrefix,
-      numberOfBins: this.numberOfBins,
-      suffixLen: this.suffixLen,
+      bit_length: this.bitLength,
+      name_prefix: this.namePrefix,
     };
 
     return json;

--- a/src/models/role.ts
+++ b/src/models/role.ts
@@ -305,7 +305,7 @@ export class SuccinctRoles extends Role {
     // Right shift hash bytes, so that we only have the leftmost
     // bit_length bits that we care about.
     const shiftValue = 32 - this.bitLength;
-    const binNumber = parseInt(hashBytes.toString('hex'), 16) >>> shiftValue;
+    const binNumber = hashBytes.readUInt32BE() >>> shiftValue;
 
     // Add zero padding if necessary and cast to hex the suffix.
     const suffix = binNumber.toString(16).padStart(this.suffixLen, '0');
@@ -343,12 +343,8 @@ export class SuccinctRoles extends Role {
       return false;
     }
 
-    try {
-      const num = parseInt(suffix, 16);
-      return 0 <= num && num < this.numberOfBins;
-    } catch (e) {
-      return false;
-    }
+    const num = parseInt(suffix, 16);
+    return 0 <= num && num < this.numberOfBins;
   }
 
   public toJSON(): JSONObject {

--- a/src/models/role.ts
+++ b/src/models/role.ts
@@ -299,11 +299,11 @@ export class SuccinctRoles extends Role {
     }
 
     try {
-      var num = parseInt(suffix, 16);
+      const num = parseInt(suffix, 16);
+      return 0 <= num && num < this.numberOfBins;
     } catch (e) {
       return false;
     }
-    return 0 <= num && num < this.numberOfBins;
   }
 
   public toJSON(): JSONObject {


### PR DESCRIPTION
```
  SuccinctRoles
    constructor
      when bit length is not valid
        ✓ constructs an object (8 ms)
        ✓ constructs an object
      when bit length is valid
        ✓ constructs an object (1 ms)
        ✓ constructs an object
    #equals
      when called with a non-SuccinctRoles object
        ✓ returns false (1 ms)
      when called with a SuccinctRoles object with different KeyIds
        ✓ returns false
      when called with a SuccinctRoles object with different threshold
        ✓ returns false
      when called with a SuccinctRoles object with different bit length
        ✓ returns false (1 ms)
      when called with a SuccinctRoles object with different prefix name
        ✓ returns false
      when called with a SuccinctRoles object with different unrecognizedFields
        ✓ returns false
      when called with the same SuccinctRoles object
        ✓ returns true (1 ms)
      when called with the a matching succinctRoles object
        ✓ returns true (2 ms)
    #getRoleForTarget
      when checked with CORRECT target bin examples
        ✓ returns true
      when checked with WRONG target bin examples
        ✓ returns false
    #getRoles
      when bit length is 1
        ✓ returns 2 bins (1 ms)
      when bit length is 4
        ✓ returns 16 bins
    #isDelegatedRole
      when called with WRONG role names
        ✓ returns false
      when called with CORRECT role names
        ✓ returns false
    #toJSON
      when bit length is 1
        ✓ returns the expected JSON
      when bit length is 32
        ✓ returns the expected JSON (1 ms)
    .fromJSON
      when there is a type error with keyids
        ✓ throws a TypeError
      when there is a type error with bit length
        ✓ throws a TypeError
      when there is a type error with name prefix
        ✓ throws a TypeError
      when there is a type error with name threshold
        ✓ throws a TypeError (1 ms)
      when the JSON is valid
        ✓ returns the expected SuccinctRoles object
```