### PR TITLE
refactor downloadBytes/downloadFile

### DIFF
--- a/src/__tests__/fetcher.test.ts
+++ b/src/__tests__/fetcher.test.ts
@@ -15,7 +15,7 @@ describe('Fetcher Test', () => {
       const fetcher = new Fetcher();
       const fromFetcher = await fetcher.downloadBytes(baseURL, 10000000000);
 
-      expect(new TextDecoder().decode(fromFetcher)).toEqual(response);
+      expect(fromFetcher).toStrictEqual(Buffer.from(response));
     });
   });
 

--- a/src/__tests__/utils/tmpfile.test.ts
+++ b/src/__tests__/utils/tmpfile.test.ts
@@ -1,13 +1,14 @@
+import fs from 'fs/promises';
 import { withTempFile } from '../../utils/tmpfile';
 
 describe('withTempFile', () => {
   it('creates a temporary file', async () => {
-    const file = await withTempFile(async (tmpFile) => {
-      expect(tmpFile).toBeTruthy();
-      return tmpFile;
+    const file = await withTempFile(async (tmpFileName) => {
+      expect(tmpFileName).toBeTruthy();
+      return tmpFileName;
     });
 
-    // Check to make sure the file is closed
-    await expect(file.readFile()).rejects.toThrow(/file closed/);
+    // Check to make sure the file has been deleted
+    await expect(fs.open(file)).rejects.toThrow(/no such file/);
   });
 });

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,58 +1,73 @@
-import fs from 'fs/promises';
+import fs from 'fs';
 import fetch from 'make-fetch-happen';
+import util from 'util';
 
 import { DownloadHTTPError, DownloadLengthMismatchError } from './error';
 import { withTempFile } from './utils/tmpfile';
 
-type DownloadFileHandler = (tmpFilePath: string) => Promise<Buffer>;
+type DownloadFileHandler<T> = (file: string) => Promise<T>;
 
 export abstract class BaseFetcher {
-  protected timeout?: number;
-
-  constructor(timeout?: number) {
-    this.timeout = timeout;
-  }
-
   abstract fetch(url: string): Promise<NodeJS.ReadableStream>;
 
-  // Download file from given ``url``.
-  public async downloadFile(
+  // Download file from given URL. The file is downloaded to a temporary
+  // location and then passed to the given handler. The handler is responsible
+  // for moving the file to its final location. The temporary file is deleted
+  // after the handler returns.
+  public async downloadFile<T>(
     url: string,
     maxLength: number,
-    handler: DownloadFileHandler
-  ): Promise<Buffer> {
-    return withTempFile(async (tmpFile, tmpFilePath) => {
+    handler: DownloadFileHandler<T>
+  ): Promise<T> {
+    return withTempFile(async (tmpFile) => {
       const reader = await this.fetch(url);
 
       let numberOfBytesReceived = 0;
+      const fileStream = fs.createWriteStream(tmpFile);
 
-      for await (const chunk of reader) {
-        const bufferChunk = Buffer.from(chunk);
-        numberOfBytesReceived += bufferChunk.length;
+      // Read the stream a chunk at a time so that we can check
+      // the length of the file as we go
+      try {
+        for await (const chunk of reader) {
+          const bufferChunk = Buffer.from(chunk);
+          numberOfBytesReceived += bufferChunk.length;
 
-        if (numberOfBytesReceived > maxLength) {
-          throw new DownloadLengthMismatchError('Max length reached');
+          if (numberOfBytesReceived > maxLength) {
+            throw new DownloadLengthMismatchError('Max length reached');
+          }
+
+          await writeBufferToStream(fileStream, bufferChunk);
         }
-        await tmpFile.write(bufferChunk);
+      } finally {
+        // Make sure we always close the stream
+        await util.promisify(fileStream.close).bind(fileStream)();
       }
-      return await handler(tmpFilePath);
+
+      return handler(tmpFile);
     });
   }
 
-  // Download bytes from given ``url``.
+  // Download bytes from given URL.
   public async downloadBytes(url: string, maxLength: number): Promise<Buffer> {
-    return await this.downloadFile(url, maxLength, async (tmpFilePath) => {
-      const readFile = await fs.open(tmpFilePath, 'r');
-      const data = await readFile.readFile();
-      readFile.close();
-      return data;
+    return this.downloadFile(url, maxLength, async (file) => {
+      const stream = fs.createReadStream(file);
+      const chunks: Buffer[] = [];
+
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      return Buffer.concat(chunks);
     });
   }
 }
 
 export class Fetcher extends BaseFetcher {
+  private timeout?: number;
+
   constructor(timeout?: number) {
-    super(timeout);
+    super();
+    this.timeout = timeout;
   }
 
   public override async fetch(url: string): Promise<NodeJS.ReadableStream> {
@@ -65,3 +80,17 @@ export class Fetcher extends BaseFetcher {
     return response.body;
   }
 }
+
+const writeBufferToStream = async (
+  stream: fs.WriteStream,
+  buffer: Buffer
+): Promise<boolean> => {
+  return new Promise((resolve, reject) => {
+    stream.write(buffer, (err) => {
+      if (err) {
+        reject(err);
+      }
+      resolve(true);
+    });
+  });
+};

--- a/src/utils/tmpfile.ts
+++ b/src/utils/tmpfile.ts
@@ -2,33 +2,24 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
-type TmpFileHandler<T> = (
-  tmpFile: fs.FileHandle,
-  tmpFilePath: string
-) => Promise<T>;
-type TmpDirHandler<T> = (dir: string) => Promise<T>;
+type TempFileHandler<T> = (file: string) => Promise<T>;
 
-// Invokes the given handler with a handle to a temporary file. The file
+// Invokes the given handler with the path to a temporary file. The file
 // is deleted after the handler returns.
-export const withTempFile = async <T>(handler: TmpFileHandler<T>): Promise<T> =>
-  withTempDir(async (dir) => {
-    const tmpFilePath = path.join(dir, 'tempfile');
-    const tmpFile = await fs.open(tmpFilePath, 'w+');
-    try {
-      return await handler(tmpFile, tmpFilePath);
-    } finally {
-      tmpFile.close();
-    }
-  });
+export const withTempFile = async <T>(
+  handler: TempFileHandler<T>
+): Promise<T> =>
+  withTempDir(async (dir) => handler(path.join(dir, 'tempfile')));
 
 // Invokes the given handler with a temporary directory. The directory is
 // deleted after the handler returns.
-const withTempDir = async <T>(handler: TmpDirHandler<T>) => {
+const withTempDir = async <T>(handler: TempFileHandler<T>) => {
   const tmpDir = await fs.realpath(os.tmpdir());
   const dir = await fs.mkdtemp(tmpDir + path.sep);
+
   try {
     return await handler(dir);
   } finally {
-    fs.rm(dir, { recursive: true });
+    await fs.rm(dir, { force: true, recursive: true, maxRetries: 3 });
   }
 };


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

Change the interface of `withTempFile` to simply return the path to the temp file instead of a `FileHandle` object. I realized that for some of the things we want to do with the file its easier to work with a `WritableStream` or `ReadableStream` than a `FileHandle`.

