### PR TITLE
Refactor Updater.downloadTarget

### DIFF
--- a/src/updater.ts
+++ b/src/updater.ts
@@ -134,8 +134,9 @@ export class Updater {
         return filePath;
       }
     } catch (error) {
-      return;
+      return undefined; // File not found
     }
+    return undefined; // File not found
   }
 
   private loadLocalMetadata(fileName: string): Buffer {
@@ -372,6 +373,7 @@ export class Updater {
         delegationsToVisit.push(...childRolesToVisit);
       }
     }
+    return undefined; // no matching target found
   }
 
   private generateTargetPath(targetInfo: TargetFile): string {

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -129,8 +129,10 @@ export class Updater {
     }
 
     try {
-      targetInfo.verify(fs.createReadStream(filePath));
-      return filePath;
+      if (fs.existsSync(filePath)) {
+        targetInfo.verify(fs.createReadStream(filePath));
+        return filePath;
+      }
     } catch (error) {
       return;
     }

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -134,9 +134,9 @@ export class Updater {
         return filePath;
       }
     } catch (error) {
-      return undefined; // File not found
+      return; // File not found
     }
-    return undefined; // File not found
+    return; // File not found
   }
 
   private loadLocalMetadata(fileName: string): Buffer {
@@ -373,7 +373,7 @@ export class Updater {
         delegationsToVisit.push(...childRolesToVisit);
       }
     }
-    return undefined; // no matching target found
+    return; // no matching target found
   }
 
   private generateTargetPath(targetInfo: TargetFile): string {


### PR DESCRIPTION
Updates the implementation of `Update.downloadTarget` so that the target file doesn't have to be read entirely into memory. With the new implementation, the target file is downloaded to a temporary file which is copied to its final destination only after the length and digest is verified.

Since we no longer have the entire target in memory, the implementation of the `verify` function had to be refactored so that the length and digest could be calculated while reading the file stream chunk-by-chunk.