### PR TITLE
TargetFile refinements

### DIFF
--- a/src/__tests__/models/file.test.ts
+++ b/src/__tests__/models/file.test.ts
@@ -255,9 +255,23 @@ describe('TargetFile', () => {
         hashes: { sha256: 'a' },
       };
 
-      it('returns undefined', () => {
+      it('returns an empty object', () => {
         const file = new TargetFile(opts);
-        expect(file.custom).toBeUndefined();
+        expect(file.custom).toEqual({});
+      });
+    });
+
+    describe('when the custom fields are malformed (not an object)', () => {
+      const opts = {
+        length: 1,
+        path: 'foo',
+        hashes: { sha256: 'a' },
+        unrecognizedFields: { custom: 'foo' },
+      };
+
+      it('returns an empty object', () => {
+        const file = new TargetFile(opts);
+        expect(file.custom).toEqual({});
       });
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { BaseFetcher } from './fetcher';
+export { TargetFile } from './models/file';
 export { Updater } from './updater';

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -148,8 +148,12 @@ export class TargetFile {
     this.unrecognizedFields = opts.unrecognizedFields || {};
   }
 
-  get custom(): JSONValue {
-    return this.unrecognizedFields['custom'];
+  get custom(): Record<string, unknown> {
+    const custom = this.unrecognizedFields['custom'];
+    if (!custom || Array.isArray(custom) || !(typeof custom === 'object')) {
+      return {};
+    }
+    return custom;
   }
 
   public equals(other: TargetFile): boolean {


### PR DESCRIPTION
Updates the return type of `TargetFile.custom()` from `JSONValue` to `Record<string, unknown>` this is both more correct (from the perspective of the TUF spec) and more usable for the consuming code.

Also exports the `TargetFile` type from the package. Since `TargetFile` is already part of our public interface (used in `Updater.downloadTarget()` and `Updater.getTargetInfo()`) it makes sense to have the type itself exported.

Signed-off-by: Brian DeHamer <bdehamer@github.com>